### PR TITLE
took away filter over images in home screen

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -24,8 +24,6 @@
 
 .hover-img:hover{
   transition: 0.3s;
-  -webkit-filter: grayscale(0.6);
-  filter: grayscale(0.6);
   .overlay-text {
     transition: 0.3s;
     opacity: 1;


### PR DESCRIPTION
After our first itineration the client decided that he didn't want a filter to alter the image when hovered on home page.